### PR TITLE
Update next SHG meeting and remove outdated events

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,34 +88,14 @@
       <h2 class="pb-2 border-bottom">Termine</h2>
       <div class="d-flex flex-column flex-md-row p-4 gap-4 py-md-5 align-items-center justify-content-center">
           <div class="list-group">       
-            <a href="https://www.regierung-mv.de/Landesregierung/bm/Aktuell/?id=212711&processor=processor.sa.pressemitteilung" class="list-group-item list-group-item-action d-flex gap-3 py-3" aria-current="true">
-              <img src="images/bookmark-heart.svg" alt="twbs" width="35" height="35" class="feature-icon">
-                <div class="d-flex gap-2 w-100 justify-content-between">
-                <div>
-                  <h6 class="mb-0">Digitale Sprechstunde für Eltern und Lehrkräfte</h6>
-                  <p class="mb-0 opacity-75">Bildungsministerin Simone Oldenburg setzt den direkten Austausch mit Eltern und Lehrkräften fort und lädt zu einer digitalen Sprechstunde ein.</p>
-                </div>
-                <small class="opacity-50 text-nowrap">30.07.2025</small>
-              </div>              
-            </a>
             <a href="https://giphy.com/gifs/rocket-launch-b85mPT4Usz7fq" class="list-group-item list-group-item-action d-flex gap-3 py-3" aria-current="true">
               <img src="images/bookmark-heart.svg" alt="twbs" width="35" height="35" class="feature-icon">
                 <div class="d-flex gap-2 w-100 justify-content-between">
                 <div>
-                  <h6 class="mb-0">4. Treffen der SHG</h6>
-                  <p class="mb-0 opacity-75">Wir treffen uns am 15. September um 18:00 Uhr im „Treff im Lindengarten“ (TiL) in der Bauhofstraße 17 in Wismar.</p>
+                  <h6 class="mb-0">Nächstes SHG-Treffen</h6>
+                  <p class="mb-0 opacity-75">Wir sehen uns am 19. September um 18:00 Uhr im „Treff im Lindengarten“ (TiL) in der Bauhofstraße 17 in Wismar.</p>
                 </div>
-                <small class="opacity-50 text-nowrap">15.09.2025</small>
-              </div>
-            </a>
-            <a href="https://giphy.com/gifs/rocket-launch-b85mPT4Usz7fq" class="list-group-item list-group-item-action d-flex gap-3 py-3" aria-current="true">
-              <img src="images/bookmark-heart.svg" alt="twbs" width="35" height="35" class="feature-icon">
-                <div class="d-flex gap-2 w-100 justify-content-between">
-                <div>
-                  <h6 class="mb-0">5. Treffen der SHG</h6>
-                  <p class="mb-0 opacity-75">Wir treffen uns am 17. Oktober um 18:00 Uhr im „Treff im Lindengarten“ (TiL) in der Bauhofstraße 17 in Wismar.</p>
-                </div>
-                <small class="opacity-50 text-nowrap">17.10.2025</small>
+                <small class="opacity-50 text-nowrap">19.09.2025</small>
               </div>
             </a>
           </div>


### PR DESCRIPTION
## Summary
- update Termine section with the next SHG meeting on 19 September 2025
- remove outdated digital talk and fifth meeting entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b9c116a0832f92f6aa7df1f61844